### PR TITLE
CLOUD-1082: add missing exec to start script

### DIFF
--- a/script/start.sh
+++ b/script/start.sh
@@ -4,7 +4,7 @@ set -e
 
 mlflow db upgrade "$JOBSERVER_RDB_URL"
 
-mlflow server \
+exec mlflow server \
     --backend-store-uri "$JOBSERVER_RDB_URL" \
     --default-artifact-root "s3://grnds-$AWS_ENVIRONMENT-cortex-shared/mlflow" \
     --host 0.0.0.0 \


### PR DESCRIPTION
Similar to: https://github.com/ConsultingMD/cortex/pull/2268

Currently the script that runs this service is missing exec, so signals (SIGTERM, SIGQUIT, etc) will not be passed to the running process. This can make deployments take longer than they need to and you'll see errors like error: `deployment "mlflow" exceeded its progress deadline because it can't shut down properly.`

