### PR TITLE
CLOUD-1082: lock sqlalchemy to <2

### DIFF
--- a/requirements/small-requirements.txt
+++ b/requirements/small-requirements.txt
@@ -4,7 +4,7 @@ pip>=20.1
 scipy
 # NB: We're specifying a test-only minimum version bound for sqlalchemy in order to reliably
 # execute schema consistency checks, the semantics of which were changed in sqlalchemy 1.3.21
-sqlalchemy>=1.3.21
+sqlalchemy>=1.3.21,<2.0.0
 ## Test-only dependencies
 pytest
 pytest-cov


### PR DESCRIPTION
Currently seeing this error on deployments: https://gist.github.com/pb-dod/36977068fec137b6f4657217f22f5f54

> AttributeError: 'Connection' object has no attribute 'connect'

This PR locks the version of sqlalchemy to <2 for now to avoid these errors until we can pull the changes from upstream to support sqlalchemy 2.