### PR TITLE
CLOUD-1082: Add infra yaml

### DIFF
--- a/platform/infrastructure.yaml
+++ b/platform/infrastructure.yaml
@@ -1,0 +1,2 @@
+type: Infrastructure
+apiVersion: v1


### PR DESCRIPTION
Currently we're unable to deploy due to this:
```
Now deploying mlflow version 997dc92ad467f5e124483caefdfd5382214286e8...
Error: gate github/branches failed: commit is not in service repo's default branch
Error: gate opslevel/maturity failed: Service is not at the minimum required maturity to deploy. Refer to the maturity report of a service via OpsLevel (https://app.opslevel.com/dashboard) for information on how to get this service to the required minimum maturity.
```

This PR fixes the issue by adding an infrastructure.yaml.