### PR TITLE
CLOUD-1082: add platform/infrastructure/global/iam.tf

### DIFF
--- a/platform/infrastructure/global/iam.tf
+++ b/platform/infrastructure/global/iam.tf
@@ -1,0 +1,3 @@
+data "aws_iam_role" "mlflow" {
+  name = "mlflow"
+}


### PR DESCRIPTION
I'm currently seeing this error when I attempt an infrastructure deploy:
```
$ tng deploy infra mlflow ebae8eabfecc652c7e157eadd795f3e80170d92a

Now deploying mlflow version ebae8eabfecc652c7e157eadd795f3e80170d92a...
Error: rpc error: code = Unknown desc = trying to create an empty pipeline: internal error
```

This PR makes the same fix as the recommendation here: https://github.com/ConsultingMD/tp/pull/1811#issuecomment-1397521642