### PR TITLE
CLOUD-1082: add no-tng-infrastructure to opslevel.yml

### DIFF
--- a/platform/infrastructure.yaml
+++ b/platform/infrastructure.yaml
@@ -1,2 +1,0 @@
-type: Infrastructure
-apiVersion: v1

--- a/platform/infrastructure/global/iam.tf
+++ b/platform/infrastructure/global/iam.tf
@@ -1,3 +1,0 @@
-data "aws_iam_role" "mlflow" {
-  name = "mlflow"
-}

--- a/platform/opslevel.yml
+++ b/platform/opslevel.yml
@@ -5,7 +5,9 @@ service:
   tier: tier_3
   lifecycle: generally_available
   language: Python
-  description: |
+  description: Open source platform for the machine learning lifecycle
   tags:
     - key: no-parameters
+      value: true
+    - key: no-tng-infrastructure
       value: true


### PR DESCRIPTION
I added this infrastructure.yaml to get this service to deploy: https://github.com/ConsultingMD/mlflow/pull/25

That caused an error because there’s no terraform directory.

Then I added this reference to an IAM role based on some comments I saw: https://github.com/ConsultingMD/mlflow/pull/26

That didn't work because there’s not already an IAM role.

I talked to @SteveRuble and he told me: "If there’s no infrastructure at all you should get an exemption for the service."

This PR adds that exemption.
